### PR TITLE
Make relative & absolute pathing work sanely

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,6 +10,8 @@ var figlet = require('figlet');
 var helpers = require('./app/helpers');
 var os = require('os');
 
+var cwd = process.cwd();
+
 figlet.text('Youtube-Dler', {
     font: 'Doom',
     horizontalLayout: 'default',
@@ -57,11 +59,18 @@ figlet.text('Youtube-Dler', {
             .alias('h', 'help')
             .example('./$0 video wZZ7oFKsKzY', 'Downloads the video located at https://youtu.be/wZZ7oFKsKzY')
             .argv
-        helpers.ensureExists(os.homedir() + '/youtube-dler/', function(err) {
+        helpers.ensureExists(helpers.resolvePath(cwd), function(err) {
             if (err) {
                 return helpers.uglify("Error: Can't create the downloads folder", err);
             } else {
-                require('./app/video').dlVideo(argv.k, argv.o, argv._[1], argv.a, argv.q, os.homedir() + '/youtube-dler/');
+                require('./app/video').dlVideo(
+                    argv.k,
+                    argv.o,
+                    argv._[1],
+                    argv.a,
+                    argv.q,
+                    helpers.resolvePath(cwd)
+                );
             }
         });
 
@@ -92,11 +101,18 @@ figlet.text('Youtube-Dler', {
             .help('h')
             .example('./$0 playlist RDwZZ7oFKsKzY', 'Downloads the playlist with list id of RDwZZ7oFKsKzY')
             .argv
-        helpers.ensureExists(os.homedir() + '/youtube-dler/', function(err) {
+        helpers.ensureExists(helpers.resolvePath(argv.o || cwd), function(err) {
             if (err) {
                 return helpers.uglify("Error: Can't create the downloads folder", err);
             } else {
-                require('./app/playlist').dlPlaylist(argv.k, argv._[1], argv.a, argv.q, !argv.r, os.homedir() + '/youtube-dler/' + argv.o);
+                require('./app/playlist').dlPlaylist(
+                    argv.k,
+                    argv._[1],
+                    argv.a,
+                    argv.q,
+                    !argv.r,
+                    helpers.resolvePath(argv.o || cwd)
+                );
             }
         });
     } else if (command === 'tracks') {
@@ -119,7 +135,7 @@ figlet.text('Youtube-Dler', {
             .help('h')
             .example('./$0 tracks sia --artist sia --album "1000 Forms Of Fear"')
             .argv;
-        require('./app/tracks')(os.homedir() + '/youtube-dler/' + argv._[1], argv.ar, argv.al, argv.c);
+        require('./app/tracks')(helpers.resolvePath(argv._[1] || cwd), argv.ar, argv.al, argv.c);
     } else {
         yargs.showHelp();
     }

--- a/app/helpers.js
+++ b/app/helpers.js
@@ -85,6 +85,9 @@ module.exports = {
         console.log(chalk.bold('encoding:'), meta.encoding);
         console.log(chalk.bold('size:'), this.toHumanSize(meta.size) + ' (' + meta.size + ' bytes)');
     },
+    resolvePath: function(destPath) {
+        return path.resolve(path.relative(process.cwd(), destPath));
+    },
     downloadVideo: function(id, title, audio, quality, path, next, check) {
         var self = this;
         var uri = "https://www.youtube.com/watch?v=" + id;


### PR DESCRIPTION
Fixes #1 

Pathing for the `--out` param, as well as the default (not specified), should perhaps (IMHO) work in a more intuitive way:

 * With no path specified, output should be in **the current directory**. Being a global command, the user may just run it in the directory they want the files in. It doesn't make much sense to send them to their home dir.
 * With `--out` specified as a relative directory, the final output directory should be resolved from the **current directory**. For instance, if I'm in `/tmp` and specify `--out=myFiles`, the output dir should be `/tmp/myFiles`.
 * With `--out` specified as an absolute directory, the final output should be to that exact dir.

Currently all three of these aspects have changed in my PR. They do not affect the current docs which don't state the exact behaviour of the `--out` parameter, but the changes will probably make it work as one might expect.